### PR TITLE
fixes for IC6 and IS6 and adding a new set of queries

### DIFF
--- a/nebula/queries/interactive-complex-6.ngql
+++ b/nebula/queries/interactive-complex-6.ngql
@@ -1,5 +1,5 @@
-GO 1 to 2 steps from $personId over KNOWS bidirect where id($$)<>$personId yield distinct id($$) as friend | \
-GO from $-.friend over HAS_CREATOR reversely where $$.Post.content IS NOT EMPTY yield id($$) as friendPost | \
-GO from $-.friendPost over HAS_TAG where $$.`Tag`.name==$tagName yield id($^) as postWithSpecifiedTag | \
-GO from $-.postWithSpecifiedTag over HAS_TAG where $$.`Tag`.name<>$tagName yield properties($$).name as otherTagName, id($^) as commonPost | \
+GO 1 to 2 steps from $personId over KNOWS bidirect where id($$)<>$personId yield distinct id($$) as friend | 
+GO from $-.friend over HAS_CREATOR reversely where $$.Post.content IS NOT EMPTY yield id($$) as friendPost | 
+GO from $-.friendPost over HAS_TAG where $$.`Tag`.name==$tagName yield id($^) as postWithSpecifiedTag | 
+GO from $-.postWithSpecifiedTag over HAS_TAG where $$.`Tag`.name<>$tagName yield properties($$).name as otherTagName, id($^) as commonPost | 
 group by $-.otherTagName yield $-.otherTagName as otherTagName, count($-.commonPost) as postCount | order by $-.postCount desc | limit 10

--- a/nebula/queries2/interactive-complex-1.ngql
+++ b/nebula/queries2/interactive-complex-1.ngql
@@ -1,0 +1,45 @@
+MATCH p=(person:Person)-[:KNOWS*1..3]-(friend:Person {firstName: $firstName})
+WHERE id(person) == $personId
+AND person <> friend
+WITH friend, length(p) AS distance
+LIMIT 20
+MATCH (friend)-[:IS_LOCATED_IN]->(friendCity:Place)
+OPTIONAL MATCH (friend)-[studyAt:STUDY_AT]->(uni:Organisation)-[:IS_LOCATED_IN]->(uniCity:Place)
+WITH
+  friend,
+  collect(
+    CASE uni.Organisation.name
+      WHEN null THEN null
+      ELSE [uni.Organisation.name, studyAt.classYear, uniCity.Place.name]
+    END
+  ) AS unis,
+  friendCity,
+  distance
+OPTIONAL MATCH (friend)-[workAt:WORK_AT]->(company:Organisation)-[:IS_LOCATED_IN]->(companyCountry:Place)
+WITH
+  friend,
+  collect(
+    CASE company.Organisation.name
+      WHEN null THEN null
+      ELSE [company.Organisation.name, workAt.workFrom, companyCountry.Place.name]
+    END
+  ) AS companies,
+  unis,
+  friendCity,
+  distance
+RETURN
+  id(friend) AS friendId,
+  friend.Person.lastName AS friendLastName,
+  distance AS distanceFromPerson,
+  friend.Person.birthday AS friendBirthday,
+  friend.Person.creationDate AS friendCreationDate,
+  friend.Person.gender AS friendGender,
+  friend.Person.browserUsed AS friendBrowserUsed,
+  friend.Person.locationIP AS friendLocationIp,
+  friend.Person.email AS friendEmails,
+  friend.Person.speaks AS friendLanguages,
+  friendCity.Place.name AS friendCityName,
+  unis AS friendUniversities,
+  companies AS friendCompanies
+ORDER BY distanceFromPerson ASC, friendLastName ASC
+LIMIT 20

--- a/nebula/queries2/interactive-complex-11.ngql
+++ b/nebula/queries2/interactive-complex-11.ngql
@@ -1,0 +1,13 @@
+MATCH (person:Person)-[:KNOWS*1..2]-(friend:Person)
+  WHERE id(person) == $personId AND not(person==friend)
+  WITH DISTINCT friend
+MATCH (friend)-[workAt:WORK_AT]->(company:Organisation)-[:IS_LOCATED_IN]->(:Place {name:"China"})
+  WHERE workAt.workFrom < $workFromYear
+  RETURN
+    id(friend) AS personId,
+    friend.Person.firstName AS personFirstName,
+    friend.Person.lastName AS personLastName,
+    company.Organisation.name AS organizationName,
+    workAt.workFrom AS organizationWorkFromYear
+    ORDER BY organizationWorkFromYear ASC, personId ASC, organizationName DESC
+    LIMIT 10

--- a/nebula/queries2/interactive-complex-12.ngql
+++ b/nebula/queries2/interactive-complex-12.ngql
@@ -1,0 +1,10 @@
+MATCH (n:Person)-[:KNOWS]-(friend:Person)<-[:COMMENT_HAS_CREATOR]-(`comment`:`Comment`)-[:REPLY_OF_POST]->(:Post)-[:HAS_TAG]->(`tag`:`Tag`)-[:HAS_TYPE]->(tagClass:Tagclass)-[:IS_SUBCLASS_OF*0..100]->(baseTagClass:Tagclass)
+  WHERE id(n) == $personId AND (tagClass.Tagclass.name == $tagClassName OR baseTagClass.Tagclass.name == $tagClassName)
+  RETURN
+    id(friend) AS personId,
+    friend.Person.firstName AS personFirstName,
+    friend.Person.lastName AS personLastName,
+    collect(DISTINCT `tag`.`Tag`.name) AS tagNames,
+    count(DISTINCT `comment`) AS replyCount
+    ORDER BY replyCount DESC, personId ASC
+    LIMIT 20

--- a/nebula/queries2/interactive-complex-13.ngql
+++ b/nebula/queries2/interactive-complex-13.ngql
@@ -1,0 +1,1 @@
+find shortest path from $person1Id to $person2Id over KNOWS yield path as p|yield collect(length($-.p)) AS l | yield case size($-.l) when 0 then -1 else $-.l[0] end;

--- a/nebula/queries2/interactive-complex-2.ngql
+++ b/nebula/queries2/interactive-complex-2.ngql
@@ -1,0 +1,17 @@
+MATCH (n:Person)-[:KNOWS]-(friend:Person)<-[:POST_HAS_CREATOR|COMMENT_HAS_CREATOR]-(message)
+  WHERE id(n) == $personId and (message.`Comment`.creationDate <= $maxDate or message.`Post`.creationDate <= $maxDate)
+  RETURN
+    id(friend) AS personId,
+    friend.Person.firstName AS personFirstName,
+    friend.Person.lastName AS personLastName,
+    id(message) AS messageId,
+    CASE exists(message.`Comment`.content)
+      WHEN true THEN coalesce(message.`Comment`.imageFile,message.`Comment`.content)
+      ELSE coalesce(message.Post.imageFile,message.Post.content)
+    END AS messageContent,
+    CASE exists(message.`Comment`.content)
+      WHEN true THEN message.`Comment`.creationDate
+      ELSE message.Post.creationDate
+    END AS messageCreationDate
+    ORDER BY messageCreationDate DESC, messageId ASC
+    LIMIT 20

--- a/nebula/queries2/interactive-complex-3.ngql
+++ b/nebula/queries2/interactive-complex-3.ngql
@@ -1,0 +1,38 @@
+MATCH (countryX:Place{name:$countryXName})
+MATCH (countryY:Place{name:$countryYName})
+MATCH (person:Person)
+  WHERE id(person) == $personId
+WITH person, id(countryX) AS countryXId, id(countryY) AS countryYId
+LIMIT 1
+MATCH (city:Place)-[:IS_PART_OF]->(country:Place)
+WITH person, id(country) AS countryId, countryXId, countryYId, id(city) AS cityId
+WHERE countryId IN [countryXId, countryYId]
+WITH person, countryXId, countryYId, collect(cityId) AS cities
+MATCH (person)-[:KNOWS*1..2]-(friend)-[:IS_LOCATED_IN]->(city)
+WITH id(person) AS personId, friend, id(city) AS cityId, cities, countryXId, countryYId
+WHERE personId<>id(friend) AND NOT cityId IN cities
+WITH DISTINCT friend, countryXId, countryYId
+MATCH (friend)<-[:POST_HAS_CREATOR|COMMENT_HAS_CREATOR]-(message)
+WHERE
+  CASE
+  WHEN $endDate > message.`Comment`.creationDate AND message.`Comment`.creationDate >= $startDate THEN true
+  WHEN $endDate > message.Post.creationDate AND message.Post.creationDate >= $startDate THEN true
+  ELSE false
+  END
+MATCH (message)-[:IS_LOCATED_IN]->(country)
+WITH friend, id(country) AS countryId, countryXId, countryYId
+WHERE countryId IN [countryXId, countryYId]
+WITH friend,
+  CASE WHEN countryId==countryYId THEN 1 ELSE 0 END AS messageX,
+  CASE WHEN countryId==countryYId THEN 1 ELSE 0 END AS messageY
+WITH friend, sum(messageX) AS xCount, sum(messageY) AS yCount
+WHERE xCount>0 AND yCount>0
+RETURN
+  id(friend) AS friendId,
+  friend.Person.firstName AS friendFirstName,
+  friend.Person.lastName AS friendLastName,
+  xCount,
+  yCount,
+  xCount + yCount AS xyCount
+  ORDER BY xyCount DESC, friendId ASC
+  LIMIT 20

--- a/nebula/queries2/interactive-complex-4.ngql
+++ b/nebula/queries2/interactive-complex-4.ngql
@@ -1,0 +1,12 @@
+MATCH (person:Person)-[:KNOWS]-(:Person)<-[:POST_HAS_CREATOR]-(post:Post)-[:HAS_TAG]->(`tag`:`Tag`)
+  WHERE id(person) == $personId AND post.Post.creationDate >= $startDate AND post.Post.creationDate < $endDate
+  WITH person, count(post) AS postsOnTag, `tag`
+  OPTIONAL MATCH (person)-[:KNOWS]-()<-[:POST_HAS_CREATOR]-(oldPost:Post)-[:HAS_TAG]->(`tag`)
+  WHERE oldPost.Post.creationDate < $startDate
+  WITH person, postsOnTag, `tag`, count(oldPost) AS cp
+  WHERE cp == 0
+  RETURN
+    `tag`.`Tag`.name AS tagName,
+    sum(postsOnTag) AS postCount
+    ORDER BY postCount DESC, tagName ASC
+    limit 10

--- a/nebula/queries2/interactive-complex-5.ngql
+++ b/nebula/queries2/interactive-complex-5.ngql
@@ -1,0 +1,12 @@
+MATCH (person:Person)-[:KNOWS*1..2]-(friend:Person)<-[membership:HAS_MEMBER]-(forum:Forum)
+  WHERE id(person) == $personId AND membership.joinDate > $minDate
+  AND not(person==friend)
+  WITH DISTINCT friend, forum
+  OPTIONAL MATCH (friend)<-[:POST_HAS_CREATOR]-(post:Post)<-[:CONTAINER_OF]-(forum)
+  WITH forum, count(post) AS postCount
+  RETURN
+    id(forum) AS forumId,
+    forum.Forum.title AS forumTitle,
+    postCount
+    ORDER BY postCount DESC, forumId ASC
+    LIMIT 20

--- a/nebula/queries2/interactive-complex-6.ngql
+++ b/nebula/queries2/interactive-complex-6.ngql
@@ -1,0 +1,5 @@
+GO 1 to 2 steps from $personId over KNOWS bidirect where id($$)<>$personId yield id($$) as friend | \
+GO from $-.friend over POST_HAS_CREATOR reversely yield id($$) as friendPost | \
+GO from $-.friendPost over HAS_TAG where $$.`Tag`.name==$tagName yield id($^) as postWithSpecifiedTag | \
+GO from $-.postWithSpecifiedTag over HAS_TAG where $$.`Tag`.name<>$tagName yield properties($$).name as otherTagName, id($^) as commonPost | \
+group by $-.otherTagName yield $-.otherTagName as otherTagName, count($-.commonPost) as postCount | order by $-.postCount desc | limit 10

--- a/nebula/queries2/interactive-complex-7.ngql
+++ b/nebula/queries2/interactive-complex-7.ngql
@@ -1,0 +1,23 @@
+MATCH (person:Person)<-[:POST_HAS_CREATOR|COMMENT_HAS_CREATOR]-(message)<-[like:LIKES]-(liker:Person)
+  WHERE id(person) == $personId
+  WITH liker, message, like.creationDate AS likeTime, person, id(message) AS messageId
+  ORDER BY likeTime DESC, messageId ASC
+  WITH
+  liker,
+  head(collect({msg:message, likeTime:likeTime})) AS latestLike,
+  person
+  OPTIONAL MATCH p = (liker)-[:KNOWS]-(person)
+  RETURN
+    id(liker) AS personId,
+    liker.Person.firstName AS personFirstName,
+    liker.Person.lastName AS personLastName,
+    latestLike.likeTime AS likeCreationDate,
+    id(latestLike.msg) AS messageId,
+    CASE exists(latestLike.msg.content)
+      WHEN true THEN latestLike.msg.content
+      ELSE latestLike.msg.imageFile
+    END AS messageContent,
+    latestLike.msg.creationDate AS messageCreationDate,
+    p IS NULL AS isNew
+    ORDER BY likeCreationDate DESC, personId ASC
+    LIMIT 20

--- a/nebula/queries2/interactive-complex-8.ngql
+++ b/nebula/queries2/interactive-complex-8.ngql
@@ -1,0 +1,12 @@
+MATCH
+  (start:Person)<-[:POST_HAS_CREATOR|COMMENT_HAS_CREATOR]-(message)<-[:REPLY_OF_COMMENT|REPLY_OF_POST]-(comment:`Comment`)-[:COMMENT_HAS_CREATOR]->(person:Person)
+  WHERE id(start) == $personId
+  RETURN
+    id(person) AS personId,
+    person.Person.firstName AS personFirstName,
+    person.Person.lastName AS personLastName,
+    comment.`Comment`.creationDate AS commentCreationDate,
+    id(comment) AS commentId,
+    comment.`Comment`.content AS commentContent
+    ORDER BY commentCreationDate DESC, commentId ASC
+    LIMIT 20

--- a/nebula/queries2/interactive-complex-9.ngql
+++ b/nebula/queries2/interactive-complex-9.ngql
@@ -1,0 +1,17 @@
+MATCH (n:Person)-[:KNOWS*1..2]-(friend:Person)<-[:POST_HAS_CREATOR|COMMENT_HAS_CREATOR]-(message)
+  WHERE id(n) == $personId AND (message.`Comment`.creationDate < $maxDate OR message.Post.creationDate < $maxDate)
+  RETURN DISTINCT
+    id(friend) AS personId,
+    friend.Person.firstName AS personFirstName,
+    friend.Person.lastName AS personLastName,
+    id(message) AS messageId,
+    CASE exists(message.`Comment`.content)
+      WHEN true THEN coalesce(message.`Comment`.imageFile,message.`Comment`.content)
+      ELSE coalesce(message.Post.imageFile,message.Post.content)    
+    END AS messageContent,
+    CASE exists(message.`Comment`.content)
+      WHEN true THEN message.`Comment`.creationDate
+      ELSE message.POST.creationDate
+    END AS messageCreationDate    
+    ORDER BY messageCreationDate DESC, messageId ASC
+    LIMIT 20

--- a/nebula/queries2/interactive-short-1.ngql
+++ b/nebula/queries2/interactive-short-1.ngql
@@ -1,0 +1,11 @@
+MATCH (n:Person)-[:IS_LOCATED_IN]->(p:Place)
+WHERE id(n)==$personId
+RETURN
+  n.Person.firstName AS firstName,
+  n.Person.lastName AS lastName,
+  n.Person.birthday AS birthday,
+  n.Person.locationIP AS locationIP,
+  n.Person.browserUsed AS browserUsed,
+  id(p) AS cityId,
+  n.Person.gender AS gender,
+  n.Person.creationDate AS creationDate

--- a/nebula/queries2/interactive-short-2.ngql
+++ b/nebula/queries2/interactive-short-2.ngql
@@ -1,0 +1,19 @@
+MATCH (n:Person)<-[:HAS_CREATOR]-(m:`Comment`)-[:REPLY_OF*0..100]->(p:Post)
+  WHERE id(n)==$personId
+MATCH (p)-[:HAS_CREATOR]->(c)
+  RETURN
+  id(m) as messageId,
+  CASE tags(m)[0]
+    WHEN "Comment" THEN coalesce(m.`Comment`.imageFile,m.`Comment`.content)
+    ELSE coalesce(m.Post.imageFile,m.Post.content)
+  END AS messageContent,
+  CASE tags(m)[0]
+    WHEN "Comment" THEN m.`Comment`.creationDate
+    ELSE m.Post.creationDate
+  END AS messageCreationDate,
+  id(p) AS originalPostId,
+  id(c) AS originalPostAuthorId,
+  c.Person.firstName as originalPostAuthorFirstName,
+  c.Person.lastName as originalPostAuthorLastName
+  ORDER BY messageCreationDate DESC
+  LIMIT 10

--- a/nebula/queries2/interactive-short-3.ngql
+++ b/nebula/queries2/interactive-short-3.ngql
@@ -1,0 +1,8 @@
+MATCH (n:Person)-[r:KNOWS]-(friend)
+  WHERE id(n) == $personId
+  RETURN
+    id(friend) AS personId,
+    friend.Person.firstName AS firstName,
+    friend.Person.lastName AS lastName,
+    r.creationDate AS friendshipCreationDate
+    ORDER BY friendshipCreationDate DESC, personId ASC

--- a/nebula/queries2/interactive-short-4.ngql
+++ b/nebula/queries2/interactive-short-4.ngql
@@ -1,0 +1,11 @@
+MATCH (m)
+  WHERE id(m) == $commentId OR id(m) == $postId
+  RETURN
+    CASE exists(m.`Comment`.creationDate)
+      WHEN true THEN m.`Comment`.creationDate
+      ELSE m.Post.creationDate
+      END AS messageCreationDate,
+    CASE exists(m.`Comment`.content)
+      WHEN true THEN coalesce(m.`Comment`.imageFile,m.`Comment`.content)
+      ELSE coalesce(m.Post.imageFile,m.Post.content)
+    END AS messageContent

--- a/nebula/queries2/interactive-short-5.ngql
+++ b/nebula/queries2/interactive-short-5.ngql
@@ -1,0 +1,6 @@
+MATCH (m)-[:POST_HAS_CREATOR|COMMENT_HAS_CREATOR]->(p:Person)
+  WHERE id(m) == $commentId OR id(m) == $postId
+  RETURN
+    id(p) AS personId,
+    p.Person.firstName AS firstName,
+    p.Person.lastName AS lastName

--- a/nebula/queries2/interactive-short-6.ngql
+++ b/nebula/queries2/interactive-short-6.ngql
@@ -1,0 +1,8 @@
+MATCH (m)-[:REPLY_OF*0..100]->(p:Post)<-[:CONTAINER_OF]-(f:Forum)-[:HAS_MODERATOR]->(mod:Person)
+  WHERE id(m) == $commentId OR id(m) == $postId
+  RETURN
+    id(f) AS forumId,
+    f.Forum.title AS forumTitle,
+    id(mod) AS moderatorId,
+    mod.Person.firstName AS moderatorFirstName,
+    mod.Person.lastName AS moderatorLastName

--- a/nebula/queries2/interactive-short-7.ngql
+++ b/nebula/queries2/interactive-short-7.ngql
@@ -1,0 +1,15 @@
+MATCH (m)<-[:REPLY_OF_COMMENT|REPLY_OF_POST]-(c:`Comment`)-[:COMMENT_HAS_CREATOR]->(p:Person)
+ WHERE id(m) == $commentId OR id(m) == $postId
+ OPTIONAL MATCH (m)-[:COMMENT_HAS_CREATOR|POST_HAS_CREATOR]->(a:Person)-[r:KNOWS]-(p)
+ RETURN
+   id(c) AS commentId,
+   c.`Comment`.content AS commentContent,
+   c.`Comment`.creationDate AS commentCreationDate,
+   id(p) AS replyAuthorId,
+   p.Person.firstName AS replyAuthorFirstName,
+   p.Person.lastName AS replyAuthorLastName,
+   CASE r
+     WHEN null THEN false
+     ELSE true
+   END AS replyAuthorKnowsOriginalMessageAuthor
+   ORDER BY commentCreationDate DESC, replyAuthorId

--- a/nebula/queries2/interactive-update-1-add-person-companies.ngql
+++ b/nebula/queries2/interactive-update-1-add-person-companies.ngql
@@ -1,0 +1,4 @@
+INSERT EDGE IF NOT EXISTS
+    WORK_AT(workFrom)
+VALUES
+    $personId->$organizationId:($worksFromYear)

--- a/nebula/queries2/interactive-update-1-add-person-tags.ngql
+++ b/nebula/queries2/interactive-update-1-add-person-tags.ngql
@@ -1,0 +1,4 @@
+INSERT EDGE IF NOT EXISTS
+    HAS_INTEREST()
+VALUES
+    $personId->$tagId:()

--- a/nebula/queries2/interactive-update-1-add-person-universities.ngql
+++ b/nebula/queries2/interactive-update-1-add-person-universities.ngql
@@ -1,0 +1,4 @@
+INSERT EDGE IF NOT EXISTS
+    STUDY_AT(classYear)
+VALUES
+    $personId->$organizationId:($studiesFromYear)

--- a/nebula/queries2/interactive-update-1-add-person.ngql
+++ b/nebula/queries2/interactive-update-1-add-person.ngql
@@ -1,0 +1,4 @@
+INSERT VERTEX IF NOT EXISTS
+    Person(firstName, lastName, gender, birthday, creationDate, locationIP, browserUsed)
+VALUES
+    $personId:($personFirstName, $personLastName, $gender, $birthday, $creationDate, $locationIP, $browserUsed);

--- a/nebula/queries2/interactive-update-2.ngql
+++ b/nebula/queries2/interactive-update-2.ngql
@@ -1,0 +1,4 @@
+INSERT EDGE IF NOT EXISTS
+    LIKES(creationDate)
+VALUES
+    $personId->$postId:($creationDate);

--- a/nebula/queries2/interactive-update-3.ngql
+++ b/nebula/queries2/interactive-update-3.ngql
@@ -1,0 +1,4 @@
+INSERT EDGE IF NOT EXISTS
+    LIKES(creationDate)
+VALUES
+    $personId->$commentId:($creationDate)

--- a/nebula/queries2/interactive-update-4-add-forum-tags.ngql
+++ b/nebula/queries2/interactive-update-4-add-forum-tags.ngql
@@ -1,0 +1,4 @@
+INSERT EDGE IF NOT EXISTS
+    HAS_TAG()
+VALUES
+    $forumId->$tagId:()

--- a/nebula/queries2/interactive-update-4-add-forum.ngql
+++ b/nebula/queries2/interactive-update-4-add-forum.ngql
@@ -1,0 +1,4 @@
+INSERT VERTEX IF NOT EXISTS
+    Forum(title, creationDate)
+VALUES
+    $forumId:($forumTitle, $creationDate)

--- a/nebula/queries2/interactive-update-5.ngql
+++ b/nebula/queries2/interactive-update-5.ngql
@@ -1,0 +1,4 @@
+INSERT EDGE IF NOT EXISTS
+    HAS_MEMBER(joinDate)
+VALUES
+    $forumId->$personId:($joinDate)

--- a/nebula/queries2/interactive-update-6-add-post-tags.ngql
+++ b/nebula/queries2/interactive-update-6-add-post-tags.ngql
@@ -1,0 +1,4 @@
+INSERT EDGE IF NOT EXISTS
+    HAS_TAG()
+VALUES
+    $postId->$tagId:()

--- a/nebula/queries2/interactive-update-6-add-post.ngql
+++ b/nebula/queries2/interactive-update-6-add-post.ngql
@@ -1,0 +1,4 @@
+INSERT VERTEX IF NOT EXISTS
+    Post(creationDate, locationIP, browserUsed, language, content, imageFile, length)
+VALUES
+    $postId:($creationDate, $locationIP, $browserUsed, $language, CASE $content == '' WHEN true THEN NULL ELSE $content END, CASE $imageFile == '' WHEN true THEN NULL ELSE $imageFile END, $length)

--- a/nebula/queries2/interactive-update-7-add-comment-tags.ngql
+++ b/nebula/queries2/interactive-update-7-add-comment-tags.ngql
@@ -1,0 +1,4 @@
+INSERT EDGE IF NOT EXISTS
+    HAS_TAG()
+VALUES
+    $commentId->$tagId:()

--- a/nebula/queries2/interactive-update-7-add-comment.ngql
+++ b/nebula/queries2/interactive-update-7-add-comment.ngql
@@ -1,0 +1,4 @@
+INSERT VERTEX IF NOT EXISTS
+    `Comment`(creationDate, locationIP, browserUsed, content, length)
+VALUES
+    $commentId:($creationDate, $locationIP, $browserUsed, $content, $length)

--- a/nebula/queries2/interactive-update-8.ngql
+++ b/nebula/queries2/interactive-update-8.ngql
@@ -1,0 +1,4 @@
+INSERT EDGE IF NOT EXISTS
+    KNOWS(creationDate)
+VALUES
+    $person1Id->$person2Id:($creationDate)

--- a/nebula/src/main/java/com/ldbc/impls/workloads/ldbc/snb/nebula/NebulaQueryStore.java
+++ b/nebula/src/main/java/com/ldbc/impls/workloads/ldbc/snb/nebula/NebulaQueryStore.java
@@ -200,7 +200,9 @@ public class NebulaQueryStore extends QueryStore {
     public String getShortQuery6MessageForum(LdbcShortQuery6MessageForum operation) {
         return prepare(
                 QueryType.InteractiveShortQuery6,
-                ImmutableMap.of(COMMENT_ID, getConverter().convertString(NebulaID.COMMENT_ID_PREFIX + getConverter().convertId(operation.messageId())))
+                ImmutableMap.of(COMMENT_ID, getConverter().convertString(NebulaID.COMMENT_ID_PREFIX + getConverter().convertId(operation.messageId())),
+                                "postId", getConverter().convertString(NebulaID.POST_ID_PREFIX + getConverter().convertId(operation.messageId())))
+
         );
     }
 


### PR DESCRIPTION
IC6: the back-slashes at the end of each line failed the execution
IS6: $postId is added back
queries2: new queries to take advantages of the newly splitted edges, such as POST_HAS_CREATOR, etc.