### PR TITLE
IC 14 improvement

### DIFF
--- a/nebula/queries/interactive-complex-14.ngql
+++ b/nebula/queries/interactive-complex-14.ngql
@@ -6,13 +6,13 @@ WITH
   [idx IN range(1, size(pathNodes)-1) | [prev IN [pathNodes[idx-1]] | [curr IN [pathNodes[idx]] | [prev, curr]]]] AS vertList
 UNWIND vertList AS c
 WITH c[0][0][0] AS prev, c[0][0][1] AS curr, personIdsInPath
-OPTIONAL MATCH (curr)<-[e:COMMENT_HAS_CREATOR]-(:`Comment`)-[:REPLY_OF_POST]->(:Post)-[:POST_HAS_CREATOR]->(prev)
-WITH count(e) AS cnt1, prev, curr, personIdsInPath
-OPTIONAL MATCH (prev)<-[e:COMMENT_HAS_CREATOR]-(:`Comment`)-[:REPLY_OF_POST]->(:Post)-[:POST_HAS_CREATOR]->(curr)
-WITH count(e) AS cnt2, cnt1, prev, curr, personIdsInPath
-OPTIONAL MATCH (prev)<-[e:COMMENT_HAS_CREATOR]-(:`Comment`)-[:REPLY_OF_COMMENT]->(:`Comment`)-[:COMMENT_HAS_CREATOR]->(curr)
-WITH count(e) AS cnt3, cnt1, cnt2, prev, curr, personIdsInPath
-OPTIONAL MATCH (curr)<-[e:COMMENT_HAS_CREATOR]-(:`Comment`)-[:REPLY_OF_COMMENT]->(:`Comment`)-[:COMMENT_HAS_CREATOR]->(prev)
-WITH count(e) AS cnt4, cnt1, cnt2, cnt3, prev, curr, personIdsInPath
+OPTIONAL MATCH (curr)<-[:COMMENT_HAS_CREATOR]-(comm:`Comment`), (prev)<-[:POST_HAS_CREATOR]-(:Post)<-[:REPLY_OF_POST]-(comm)
+WITH count(comm) AS cnt1, prev, curr, personIdsInPath
+OPTIONAL MATCH (prev)<-[:COMMENT_HAS_CREATOR]-(comm:`Comment`), (curr)<-[:POST_HAS_CREATOR]-(:Post)<-[:REPLY_OF_POST]-(comm)
+WITH count(comm) AS cnt2, cnt1, prev, curr, personIdsInPath
+OPTIONAL MATCH (prev)<-[:COMMENT_HAS_CREATOR]-(comm:`Comment`)-[:REPLY_OF_COMMENT]->(comm2:`Comment`), (curr)<-[:COMMENT_HAS_CREATOR]-(comm2)
+WITH count(comm) AS cnt3, cnt1, cnt2, prev, curr, personIdsInPath
+OPTIONAL MATCH (curr)<-[:COMMENT_HAS_CREATOR]-(comm:`Comment`)-[:REPLY_OF_COMMENT]->(comm2:`Comment`), (prev)<-[:COMMENT_HAS_CREATOR]-(comm2)
+WITH count(comm) AS cnt4, cnt1, cnt2, cnt3, prev, curr, personIdsInPath
 RETURN personIdsInPath, sum(cnt1 + cnt2 + 0.5 * cnt3 + 0.5 * cnt4) AS pathWeight
 ORDER BY pathWeight DESC, personIdsInPath DESC


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 


#### Description:

```

(root@nebula) [sf100]> """
                    -> MATCH p = allShortestPaths((person1)-[:KNOWS*..15]-(person2))
                    -> WHERE id(person1) == "p-8796093163356" and id(person2) == "p-15393162953088"
                    -> WITH nodes(p) AS pathNodes
                    -> WITH
                    ->   [n IN pathNodes | id(n)] AS personIdsInPath,
                    ->   [idx IN range(1, size(pathNodes)-1) | [pr IN [pathNodes[idx-1]] | [cr IN [pathNodes[idx]] | [pr, cr]]]] AS vertList
                    -> UNWIND vertList AS c
                    -> WITH c[0][0][0] AS prev, c[0][0][1] AS curr, personIdsInPath
                    -> OPTIONAL MATCH (curr)<-[:COMMENT_HAS_CREATOR]-(comm:`Comment`)-[:REPLY_OF_POST]->(post), (prev)<-[:POST_HAS_CREATOR]-(post:Post)
                    -> WITH count(comm) AS cnt1, prev, curr, personIdsInPath
                    -> OPTIONAL MATCH (prev)<-[:COMMENT_HAS_CREATOR]-(comm:`Comment`)-[:REPLY_OF_POST]->(post), (curr)<-[:POST_HAS_CREATOR]-(post:Post)
                    -> WITH count(comm) AS cnt2, cnt1, prev, curr, personIdsInPath
                    -> OPTIONAL MATCH (prev)<-[:COMMENT_HAS_CREATOR]-(comm:`Comment`)-[:REPLY_OF_COMMENT]->(comm2), (curr)<-[:COMMENT_HAS_CREATOR]-(comm2:`Comment`)
                    -> WITH count(comm) AS cnt3, cnt1, cnt2, prev, curr, personIdsInPath
                    -> OPTIONAL MATCH (curr)<-[:COMMENT_HAS_CREATOR]-(comm:`Comment`)-[:REPLY_OF_COMMENT]->(comm2), (prev)<-[:COMMENT_HAS_CREATOR]-(comm2:`Comment`)
                    -> WITH count(comm) AS cnt4, cnt1, cnt2, cnt3, prev, curr, personIdsInPath
                    -> RETURN personIdsInPath, sum(cnt1 + cnt2 + 0.5 * cnt3 + 0.5 * cnt4) AS pathWeight
                    -> ORDER BY pathWeight DESC, personIdsInPath DESC
                    -> """
+--------------------------------------------------------------------------------+------------+
| personIdsInPath                                                                | pathWeight |
+--------------------------------------------------------------------------------+------------+
| ["p-8796093163356", "p-8796093166142", "p-28587302541048", "p-15393162953088"] | 7.0        |
+--------------------------------------------------------------------------------+------------+
Got 1 rows (time spent 192.979ms/194.575754ms)

Execution Plan (optimize time 1825 us)


Mon, 05 Dec 2022 14:02:07 CST

(root@nebula) [sf100]> """
                    -> MATCH p = allShortestPaths((person1)-[:KNOWS*..15]-(person2))
                    -> WHERE id(person1) == "p-8796093163356" and id(person2) == "p-15393162953088"
                    -> WITH nodes(p) AS pathNodes
                    -> WITH
                    ->   [n IN pathNodes | id(n)] AS personIdsInPath,
                    ->   [idx IN range(1, size(pathNodes)-1) | [prev IN [pathNodes[idx-1]] | [curr IN [pathNodes[idx]] | [prev, curr]]]] AS vertList
                    -> UNWIND vertList AS c
                    -> WITH c[0][0][0] AS prev, c[0][0][1] AS curr, personIdsInPath
                    -> OPTIONAL MATCH (curr)<-[:COMMENT_HAS_CREATOR]-(comm:`Comment`), (prev)<-[:POST_HAS_CREATOR]-(:Post)<-[:REPLY_OF_POST]-(comm)
                    -> WITH count(comm) AS cnt1, prev, curr, personIdsInPath
                    -> OPTIONAL MATCH (prev)<-[:COMMENT_HAS_CREATOR]-(comm:`Comment`), (curr)<-[:POST_HAS_CREATOR]-(:Post)<-[:REPLY_OF_POST]-(comm)
                    -> WITH count(comm) AS cnt2, cnt1, prev, curr, personIdsInPath
                    -> OPTIONAL MATCH (prev)<-[:COMMENT_HAS_CREATOR]-(comm:`Comment`)-[:REPLY_OF_COMMENT]->(comm2), (curr)<-[:COMMENT_HAS_CREATOR]-(comm2:`Comment`)
                    -> WITH count(comm) AS cnt3, cnt1, cnt2, prev, curr, personIdsInPath
                    -> OPTIONAL MATCH (curr)<-[:COMMENT_HAS_CREATOR]-(comm:`Comment`)-[:REPLY_OF_COMMENT]->(comm2), (prev)<-[:COMMENT_HAS_CREATOR]-(comm2:`Comment`)
                    -> WITH count(comm) AS cnt4, cnt1, cnt2, cnt3, prev, curr, personIdsInPath
                    -> RETURN personIdsInPath, sum(cnt1 + cnt2 + 0.5 * cnt3 + 0.5 * cnt4) AS pathWeight
                    -> ORDER BY pathWeight DESC, personIdsInPath DESC
                    -> """
+--------------------------------------------------------------------------------+------------+
| personIdsInPath                                                                | pathWeight |
+--------------------------------------------------------------------------------+------------+
| ["p-8796093163356", "p-8796093166142", "p-28587302541048", "p-15393162953088"] | 7.0        |
+--------------------------------------------------------------------------------+------------+
Got 1 rows (time spent 158.145ms/159.915819ms)

Execution Plan (optimize time 1862 us)


Mon, 05 Dec 2022 14:02:23 CST

(root@nebula) [sf100]> """
                    -> MATCH p = allShortestPaths((person1)-[:KNOWS*..15]-(person2))
                    -> WHERE id(person1) == "p-8796093163356" and id(person2) == "p-15393162953088"
                    -> WITH nodes(p) AS pathNodes
                    -> WITH
                    ->   [n IN pathNodes | id(n)] AS personIdsInPath,
                    ->   [idx IN range(1, size(pathNodes)-1) | [prev IN [pathNodes[idx-1]] | [curr IN [pathNodes[idx]] | [prev, curr]]]] AS vertList
                    -> UNWIND vertList AS c
                    -> WITH c[0][0][0] AS prev, c[0][0][1] AS curr, personIdsInPath
                    -> OPTIONAL MATCH (curr)<-[e:COMMENT_HAS_CREATOR]-(:`Comment`)-[:REPLY_OF_POST]->(:Post)-[:POST_HAS_CREATOR]->(prev)
                    -> WITH count(e) AS cnt1, prev, curr, personIdsInPath
                    -> OPTIONAL MATCH (prev)<-[e:COMMENT_HAS_CREATOR]-(:`Comment`)-[:REPLY_OF_POST]->(:Post)-[:POST_HAS_CREATOR]->(curr)
                    -> WITH count(e) AS cnt2, cnt1, prev, curr, personIdsInPath
                    -> OPTIONAL MATCH (prev)<-[e:COMMENT_HAS_CREATOR]-(:`Comment`)-[:REPLY_OF_COMMENT]->(:`Comment`)-[:COMMENT_HAS_CREATOR]->(curr)
                    -> WITH count(e) AS cnt3, cnt1, cnt2, prev, curr, personIdsInPath
                    -> OPTIONAL MATCH (curr)<-[e:COMMENT_HAS_CREATOR]-(:`Comment`)-[:REPLY_OF_COMMENT]->(:`Comment`)-[:COMMENT_HAS_CREATOR]->(prev)
                    -> WITH count(e) AS cnt4, cnt1, cnt2, cnt3, prev, curr, personIdsInPath
                    -> RETURN personIdsInPath, sum(cnt1 + cnt2 + 0.5 * cnt3 + 0.5 * cnt4) AS pathWeight
                    -> ORDER BY pathWeight DESC, personIdsInPath DESC
                    -> """
+--------------------------------------------------------------------------------+------------+
| personIdsInPath                                                                | pathWeight |
+--------------------------------------------------------------------------------+------------+
| ["p-8796093163356", "p-8796093166142", "p-28587302541048", "p-15393162953088"] | 7.0        |
+--------------------------------------------------------------------------------+------------+
Got 1 rows (time spent 267.588ms/269.608547ms)

Execution Plan (optimize time 1469 us)

```

## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


